### PR TITLE
Release v0.4.0

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,8 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-feature android:name="android.hardware.usb.host" android:required="true"/>
+    <uses-feature android:name="android.hardware.microphone" android:required="false" />
+    <uses-feature android:name="android.hardware.camera" android:required="false" />
     <!-- Android TV -->
     <uses-feature android:name="android.software.leanback" android:required="false" />
     <uses-feature android:name="android.hardware.touchscreen" android:required="false" />
@@ -14,6 +16,8 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="android.permission.CAMERA" />
 
     <application
         android:name=".MainApplication"

--- a/app/src/main/cpp/libusb_src/libusb/os/linux_usbfs.h
+++ b/app/src/main/cpp/libusb_src/libusb/os/linux_usbfs.h
@@ -73,7 +73,7 @@ struct usbfs_iso_packet_desc {
 #define MAX_BULK_BUFFER_LENGTH		16384
 #define MAX_CTRL_BUFFER_LENGTH		4096
 
-#define MAX_ISO_PACKETS_PER_URB		128
+#define MAX_ISO_PACKETS_PER_URB		5
 
 struct usbfs_urb {
 	unsigned char type;

--- a/app/src/main/java/com/techphenom/usbipserver/server/AttachedDeviceContext.kt
+++ b/app/src/main/java/com/techphenom/usbipserver/server/AttachedDeviceContext.kt
@@ -4,15 +4,21 @@ import android.hardware.usb.UsbDevice
 import android.hardware.usb.UsbDeviceConnection
 import android.hardware.usb.UsbEndpoint
 import android.util.SparseArray
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.sync.Mutex
-import java.util.HashSet
+import kotlinx.coroutines.sync.Semaphore
 class AttachedDeviceContext {
     lateinit var device: UsbDevice
     lateinit var devConn: UsbDeviceConnection
-    var activeConfiguration: UsbConfiguration? = null
-    var activeConfigurationEndpointsByNumDir: SparseArray<UsbEndpoint>? = null// SparseArray()
-    var activeMessages: HashSet<Int> = HashSet() // msg.seqNum
-    val activeMessagesMutex = Mutex()
+    var activeConfig: UsbConfiguration? = null
+    var activeConfigEndpointCache: SparseArray<UsbEndpoint>? = null
+    val activeJobs = mutableMapOf<Int, Job>()
+    val activeJobsMutex = Mutex()
     val socketWriteMutex = Mutex()
+    val transferSemaphore = Semaphore(permits = MAX_CONCURRENT_TRANSFERS)
     var totalEndpointCount: Int = 0
+
+    companion object {
+        const val MAX_CONCURRENT_TRANSFERS = 50
+    }
 }

--- a/app/src/main/java/com/techphenom/usbipserver/server/protocol/ongoing/UsbIpBasicPacket.kt
+++ b/app/src/main/java/com/techphenom/usbipserver/server/protocol/ongoing/UsbIpBasicPacket.kt
@@ -87,11 +87,14 @@ abstract class UsbIpBasicPacket {
     }
 
     data class UsbIpIsoPacketDescriptor(
-        val offset: Int,
-        val length: Int,
-        val actualLength: Int,
-        val status: Int
+        var offset: Int,
+        var length: Int,
+        var actualLength: Int,
+        var status: Int
     ) {
+        override fun toString(): String {
+            return "[Offset: $offset, Len: $length, Actual Len: $actualLength, Status: $status]"
+        }
         companion object {
             const val WIRE_SIZE = 16
         }

--- a/app/src/main/java/com/techphenom/usbipserver/server/protocol/ongoing/UsbIpBasicPacket.kt
+++ b/app/src/main/java/com/techphenom/usbipserver/server/protocol/ongoing/UsbIpBasicPacket.kt
@@ -1,6 +1,5 @@
 package com.techphenom.usbipserver.server.protocol.ongoing
 
-import com.techphenom.usbipserver.server.protocol.utils.Logger
 import com.techphenom.usbipserver.server.protocol.utils.convertInputStreamToByteArray
 import java.io.IOException
 import java.io.InputStream
@@ -76,17 +75,25 @@ abstract class UsbIpBasicPacket {
         const val USBIP_HEADER_SIZE = 48
 
         @Throws(IOException::class)
-        fun read(incoming: InputStream): UsbIpBasicPacket? {
+        fun read(incoming: InputStream): UsbIpBasicPacket {
             val bb = ByteBuffer.allocate(20)
             convertInputStreamToByteArray(incoming, bb.array())
             return when (val command = bb.getInt()) {
                 USBIP_CMD_SUBMIT -> UsbIpSubmitUrb.read(bb.array(), incoming)
                 USBIP_CMD_UNLINK -> UsbIpUnlinkUrb.read(bb.array(), incoming)
-                else -> {
-                    Logger.e("UsbIpServerDebug", "Unknown command: $command")
-                    null
-                }
+                else -> throw IOException("Unknown incoming packet command: $command")
             }
+        }
+    }
+
+    data class UsbIpIsoPacketDescriptor(
+        val offset: Int,
+        val length: Int,
+        val actualLength: Int,
+        val status: Int
+    ) {
+        companion object {
+            const val WIRE_SIZE = 16
         }
     }
 }

--- a/app/src/main/java/com/techphenom/usbipserver/server/protocol/ongoing/UsbIpSubmitUrb.kt
+++ b/app/src/main/java/com/techphenom/usbipserver/server/protocol/ongoing/UsbIpSubmitUrb.kt
@@ -19,6 +19,7 @@ class UsbIpSubmitUrb(header: ByteArray) : UsbIpBasicPacket(header) {
     var outData: ByteArray = ByteArray(0)
 
     override fun toString(): String {
+        val isoPacketDescriptorsString =  isoPacketDescriptors.joinToString(separator = "\n", postfix = ",") { it.toString() }
         return """
             USBIP_CMD_SUBMIT
                 ${super.toString()},
@@ -27,7 +28,8 @@ class UsbIpSubmitUrb(header: ByteArray) : UsbIpBasicPacket(header) {
                 Start Frame: $startFrame,
                 Number of Packets: $numberOfPackets,
                 Interval: $interval,
-                Setup: $setup
+                Setup: ${if(setup.isEmpty()) "[]" else setup.toString()}
+                ISO Packet Descriptors: ${if(isoPacketDescriptors.isEmpty()) "[]" else isoPacketDescriptorsString}
             """
     }
 
@@ -101,6 +103,10 @@ class UsbIpSubmitUrb(header: ByteArray) : UsbIpBasicPacket(header) {
             _value = bb.getShort()
             _index = bb.getShort()
             _length = bb.getShort()
+        }
+
+        fun isEmpty(): Boolean {
+            return requestType == 0 && request == 0 && value == 0 && index == 0 && length == 0
         }
 
         override fun toString(): String {

--- a/app/src/main/java/com/techphenom/usbipserver/server/protocol/ongoing/UsbIpSubmitUrbReply.kt
+++ b/app/src/main/java/com/techphenom/usbipserver/server/protocol/ongoing/UsbIpSubmitUrbReply.kt
@@ -42,6 +42,7 @@ class UsbIpSubmitUrbReply(seqNum: Int, devId: Int, dir: Int, ep: Int) :
     }
 
     override fun toString(): String {
+        val isoPacketDescriptorsString = isoPacketDescriptors.joinToString(separator = "\n", postfix = ",") { it.toString() }
         return """
             USBIP_RET_SUBMIT
                 ${super.toString()},
@@ -50,6 +51,7 @@ class UsbIpSubmitUrbReply(seqNum: Int, devId: Int, dir: Int, ep: Int) :
                 Start Frame: $startFrame,
                 Number of Packets: $numberOfPackets,
                 Error Count: $errorCount
+                ISO Packet Descriptors: $isoPacketDescriptorsString
             """
     }
 }

--- a/app/src/main/java/com/techphenom/usbipserver/server/protocol/usb/UsbLib.kt
+++ b/app/src/main/java/com/techphenom/usbipserver/server/protocol/usb/UsbLib.kt
@@ -6,7 +6,7 @@ class UsbLib {
         System.loadLibrary("usbipfunctions")
     }
 
-    external fun init(): Int
+    external fun init(debug: Boolean): Int
     external fun exit()
 
     external fun doControlTransfer(

--- a/app/src/main/java/com/techphenom/usbipserver/server/protocol/usb/UsbLib.kt
+++ b/app/src/main/java/com/techphenom/usbipserver/server/protocol/usb/UsbLib.kt
@@ -34,4 +34,11 @@ class UsbLib {
         timeout: Int
     ): Int
 
+    external fun doIsochronousTransfer(
+        fd: Int,
+        endpoint: Int,
+        data: ByteArray?,
+        isoPacketLengths: IntArray
+    ): Int
+
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id("com.android.application") version "8.13.0" apply false
+    id("com.android.application") version "8.13.1" apply false
     id("org.jetbrains.kotlin.android") version "2.2.0" apply false
     id("org.jetbrains.kotlin.plugin.compose") version "2.2.0" apply false
     id("com.google.dagger.hilt.android") version "2.57" apply false

--- a/gradle.properties
+++ b/gradle.properties
@@ -24,5 +24,5 @@ android.nonTransitiveRClass=true
 
 # Application Versioning
 APP_VERSION_MAJOR=0
-APP_VERSION_MINOR=3
+APP_VERSION_MINOR=4
 APP_VERSION_PATCH=0


### PR DESCRIPTION
## Changes :gear: 
- Control requests now run by themselves to prevent other currently running transfers to stall when processing a set_config or set_interface
- ISO transfers are now at least being handled. Unfortunately, I believe this setup is too slow to handle the real-time video streaming. During testing the video feed was all garbled. I'm most likely going to need to rearchitect handleOngoingRequest to support libusb's Async API. I have an idea on how I can do that.
- A big improvement for this release - connecting a dolphinbar to Unraid's USB/IP plugin and passing that into my windows VM is kind of working now. Before it wouldn't at all. The moonlight stream gets choppy tho. I have to check how much bandwidth this app uses to send the USB data back and forth.