### PR TITLE
Release 0.5.1

### DIFF
--- a/app/src/main/java/com/techphenom/usbipserver/server/AttachedDeviceContext.kt
+++ b/app/src/main/java/com/techphenom/usbipserver/server/AttachedDeviceContext.kt
@@ -51,9 +51,5 @@ class AttachedDeviceContext {
         val socket: Socket,
         val request: UsbIpSubmitUrb,
         var transferBuffer: ByteBuffer
-    ) {
-        fun updateBuffer(data: ByteBuffer) {
-            transferBuffer = data
-        }
-    }
+    )
 }

--- a/app/src/main/java/com/techphenom/usbipserver/server/AttachedDeviceContext.kt
+++ b/app/src/main/java/com/techphenom/usbipserver/server/AttachedDeviceContext.kt
@@ -21,7 +21,6 @@ class AttachedDeviceContext {
     var activeConfigEndpointCache: SparseArray<UsbEndpoint>? = null
     val pendingTransfers: MutableMap<Int, PendingTransfer> = ConcurrentHashMap()
     val transferSemaphore = Semaphore(permits = MAX_CONCURRENT_TRANSFERS)
-    var totalEndpointCount: Int = 0
     val replyChannel = Channel<UsbIpBasicPacket>(Channel.UNLIMITED)
     private val bufferPool = ConcurrentLinkedQueue<ByteBuffer>()
 

--- a/app/src/main/java/com/techphenom/usbipserver/server/UsbIpDeviceConstants.kt
+++ b/app/src/main/java/com/techphenom/usbipserver/server/UsbIpDeviceConstants.kt
@@ -22,17 +22,15 @@ class UsbIpDeviceConstants {
 
     companion object {
         const val USB_SPEED_UNKNOWN = 0
-        const val USB_SPEED_LOW = 1 // Low Speed (1.5Mbps)
-        const val USB_SPEED_FULL = 2 // Full Speed(12Mbps)
-        const val USB_SPEED_HIGH = 3 // High Speed(480Mbps)
+        const val USB_SPEED_LOW = 1 // USB 1.0 (1.5Mbps)
+        const val USB_SPEED_FULL = 2 // USB 1.1 (12Mbps)
+        const val USB_SPEED_HIGH = 3 // USB 2.0 (480Mbps)
         const val USB_SPEED_WIRELESS = 4 // Wireless (53.3-480)
-        const val USB_SPEED_SUPER = 5 // Super Speed(5000Mbps)
+        const val USB_SPEED_SUPER = 5 // USB 3.0 (5000Mbps)
 
         const val BUS_ID_SIZE = 32
         const val DEV_PATH_SIZE = 256
 
         const val WIRE_LENGTH = BUS_ID_SIZE + DEV_PATH_SIZE + 24
-
-
     }
 }

--- a/app/src/main/java/com/techphenom/usbipserver/server/protocol/ongoing/UsbIpSubmitUrb.kt
+++ b/app/src/main/java/com/techphenom/usbipserver/server/protocol/ongoing/UsbIpSubmitUrb.kt
@@ -69,7 +69,7 @@ class UsbIpSubmitUrb(header: ByteArray) : UsbIpBasicPacket(header) {
                 val isoBuff = ByteBuffer.wrap(allIsoDescriptorsBytes).order(ByteOrder.BIG_ENDIAN)
                 val descriptors = ArrayList<UsbIpIsoPacketDescriptor>(msg.numberOfPackets)
 
-                for (i in 0 until msg.numberOfPackets) {
+                repeat(msg.numberOfPackets) {
                     val offset = isoBuff.getInt()
                     val length = isoBuff.getInt()
                     val actualLength = isoBuff.getInt()
@@ -203,7 +203,7 @@ class UsbIpSubmitUrb(header: ByteArray) : UsbIpBasicPacket(header) {
             if (value and USBIP_URB_ZERO_PACKET != 0) flags.add("ZERO_PACKET")
             if (value and USBIP_URB_NO_INTERRUPT != 0) flags.add("NO_INTERRUPT")
             if (value and USBIP_URB_FREE_BUFFER != 0) flags.add("FREE_BUFFER")
-            if (value and USBIP_URB_DIR_IN != 0) flags.add("DIR_IN")
+            if (value and USBIP_URB_DIR_IN != 0) flags.add("DIR_IN") else flags.add("DIR_OUT")
 
             // Kernel internal memory flags (rarely seen but part of the protocol)
             if (value and USBIP_URB_DMA_MAP_SINGLE != 0) flags.add("DMA_MAP_SINGLE")
@@ -225,8 +225,6 @@ class UsbIpSubmitUrb(header: ByteArray) : UsbIpBasicPacket(header) {
             const val USBIP_URB_NO_INTERRUPT = 0x0080
             const val USBIP_URB_FREE_BUFFER = 0x0100
             const val USBIP_URB_DIR_IN = 0x0200
-            const val USBIP_URB_DIR_OUT = 0
-            const val USBIP_URB_DIR_MASK = USBIP_URB_DIR_IN
 
             const val USBIP_URB_DMA_MAP_SINGLE = 0x00010000
             const val USBIP_URB_DMA_MAP_PAGE = 0x00020000
@@ -235,7 +233,6 @@ class UsbIpSubmitUrb(header: ByteArray) : UsbIpBasicPacket(header) {
             const val USBIP_URB_SETUP_MAP_SINGLE = 0x00100000
             const val USBIP_URB_SETUP_MAP_LOCAL = 0x00200000
             const val USBIP_URB_DMA_SG_COMBINED = 0x00400000
-            const val USBIP_URB_ALIGNED_TEMP_BUFFER = 0x00800000
         }
     }
 }

--- a/app/src/main/java/com/techphenom/usbipserver/server/protocol/ongoing/UsbIpSubmitUrb.kt
+++ b/app/src/main/java/com/techphenom/usbipserver/server/protocol/ongoing/UsbIpSubmitUrb.kt
@@ -1,6 +1,7 @@
 package com.techphenom.usbipserver.server.protocol.ongoing
 
 import com.techphenom.usbipserver.server.protocol.utils.convertInputStreamToByteArray
+import com.techphenom.usbipserver.server.protocol.utils.intToBinary
 import com.techphenom.usbipserver.server.protocol.utils.intToHex
 import java.io.IOException
 import java.io.InputStream
@@ -8,7 +9,7 @@ import java.nio.ByteBuffer
 import java.nio.ByteOrder
 
 class UsbIpSubmitUrb(header: ByteArray) : UsbIpBasicPacket(header) {
-    var transferFlags = 0
+    var transferFlags = UsbIpTransferFlags(0)
     var transferBufferLength = 0
     var startFrame = 0
     var numberOfPackets = 0
@@ -23,7 +24,7 @@ class UsbIpSubmitUrb(header: ByteArray) : UsbIpBasicPacket(header) {
         return """
             USBIP_CMD_SUBMIT
                 ${super.toString()},
-                Transfer Flags: ${intToHex(transferFlags)},
+                Transfer Flags: $transferFlags,
                 Transfer Buffer Length: $transferBufferLength,
                 Start Frame: $startFrame,
                 Number of Packets: $numberOfPackets,
@@ -46,7 +47,7 @@ class UsbIpSubmitUrb(header: ByteArray) : UsbIpBasicPacket(header) {
             val continuationHeader = ByteArray(WIRE_SIZE)
             convertInputStreamToByteArray(incoming, continuationHeader)
             val bb = ByteBuffer.wrap(continuationHeader).order(ByteOrder.BIG_ENDIAN)
-            msg.transferFlags = bb.getInt()
+            msg.transferFlags = UsbIpTransferFlags(bb.getInt())
             msg.transferBufferLength = bb.getInt()
             msg.startFrame = bb.getInt()
             msg.numberOfPackets = bb.getInt()
@@ -97,6 +98,9 @@ class UsbIpSubmitUrb(header: ByteArray) : UsbIpBasicPacket(header) {
         val length: Int get() = _length.toInt() and 0xFFFF
         val bytes: ByteArray get() = _bytes
 
+        val reqDirection: Int get() = requestType and 0x80
+        val reqType: Int get() = (requestType and 0x60) shr 5
+        val reqRecipient: Int get() = requestType and 0x1f
 
         init {
             require(bytes.size == CONTROL_SETUP_WIRE_SIZE) { "Setup packet must be 8 bytes long" }
@@ -117,8 +121,8 @@ class UsbIpSubmitUrb(header: ByteArray) : UsbIpBasicPacket(header) {
 
         override fun toString(): String {
             return """ [
-                requestType=${intToHex(requestType)},
-                request=${intToHex(request)},
+                requestType=${intToBinary(requestType)}: ${printRequestType(reqDirection, reqType, reqRecipient)},
+                request=${intToHex(request)}: ${printRequest(reqType,request)},
                 value=${intToHex(value)},
                 index=${intToHex(index)},
                 length=$length
@@ -127,6 +131,111 @@ class UsbIpSubmitUrb(header: ByteArray) : UsbIpBasicPacket(header) {
 
         companion object {
             const val CONTROL_SETUP_WIRE_SIZE = 8
+
+            private fun printRequestType(direction: Int, type: Int, recipient: Int ): String {
+                val direction = if (direction != 0) "IN" else "OUT"
+                val type = when (type) {
+                    0 -> "Standard"
+                    1 -> "Class"
+                    2 -> "Vendor"
+                    else -> "Reserved"
+                }
+                val recipient = when (recipient) {
+                    0 -> "Device"
+                    1 -> "Interface"
+                    2 -> "Endpoint"
+                    3 -> "Other"
+                    else -> "Reserved"
+                }
+                return "Direction: $direction, Type: $type, Recipient: $recipient"
+            }
+            private fun printRequest(type: Int, value: Int): String {
+                return when (type) {
+                    0 -> printStandardRequest(value) // Standard
+                    1 -> printClassRequest(value)    // Class
+                    2 -> "Vendor-Specific Request"   // Vendor
+                    else -> "Reserved"
+                }
+            }
+
+            private fun printStandardRequest(value: Int): String {
+                return when (value) {
+                    0x00 -> "GET_STATUS"
+                    0x01 -> "CLEAR_FEATURE"
+                    0x03 -> "SET_FEATURE"
+                    0x05 -> "SET_ADDRESS"
+                    0x06 -> "GET_DESCRIPTOR"
+                    0x07 -> "SET_DESCRIPTOR"
+                    0x08 -> "GET_CONFIGURATION"
+                    0x09 -> "SET_CONFIGURATION"
+                    0x0A -> "GET_INTERFACE"
+                    0x0B -> "SET_INTERFACE"
+                    0x0C -> "SYNCH_FRAME"
+                    else -> "Unknown Standard Request"
+                }
+            }
+
+            private fun printClassRequest(value: Int): String {
+                return when (value) {
+                    0x01 -> "HID: GET_REPORT"
+                    0x09 -> "HID: SET_REPORT"
+                    0x0A -> "HID: SET_IDLE"
+
+                    0x00 -> "HUB: GET_STATUS"
+                    0x03 -> "HUB: SET_FEATURE"
+                    else -> "Unknown Class Request"
+                }
+            }
+        }
+    }
+
+    @JvmInline
+    value class UsbIpTransferFlags(val value: Int) {
+        operator fun contains(flag: Int): Boolean {
+            return (value and flag) != 0
+        }
+
+        override fun toString(): String {
+            val flags = mutableListOf<String>()
+            if (value and USBIP_URB_SHORT_NOT_OK != 0) flags.add("SHORT_NOT_OK")
+            if (value and USBIP_URB_ISO_ASAP != 0) flags.add("ISO_ASAP")
+            if (value and USBIP_URB_NO_TRANSFER_DMA_MAP != 0) flags.add("NO_TRANSFER_DMA_MAP")
+            if (value and USBIP_URB_ZERO_PACKET != 0) flags.add("ZERO_PACKET")
+            if (value and USBIP_URB_NO_INTERRUPT != 0) flags.add("NO_INTERRUPT")
+            if (value and USBIP_URB_FREE_BUFFER != 0) flags.add("FREE_BUFFER")
+            if (value and USBIP_URB_DIR_IN != 0) flags.add("DIR_IN")
+
+            // Kernel internal memory flags (rarely seen but part of the protocol)
+            if (value and USBIP_URB_DMA_MAP_SINGLE != 0) flags.add("DMA_MAP_SINGLE")
+            if (value and USBIP_URB_DMA_MAP_PAGE != 0) flags.add("DMA_MAP_PAGE")
+            if (value and USBIP_URB_DMA_MAP_SG != 0) flags.add("DMA_MAP_SG")
+            if (value and USBIP_URB_MAP_LOCAL != 0) flags.add("MAP_LOCAL")
+            if (value and USBIP_URB_SETUP_MAP_SINGLE != 0) flags.add("SETUP_MAP_SINGLE")
+            if (value and USBIP_URB_SETUP_MAP_LOCAL != 0) flags.add("SETUP_MAP_LOCAL")
+            if (value and USBIP_URB_DMA_SG_COMBINED != 0) flags.add("DMA_SG_COMBINED")
+
+            return if (flags.isEmpty()) "None" else flags.joinToString(" | ")
+        }
+
+        companion object {
+            const val USBIP_URB_SHORT_NOT_OK = 0x0001
+            const val USBIP_URB_ISO_ASAP = 0x0002
+            const val USBIP_URB_NO_TRANSFER_DMA_MAP = 0x0004
+            const val USBIP_URB_ZERO_PACKET = 0x0040
+            const val USBIP_URB_NO_INTERRUPT = 0x0080
+            const val USBIP_URB_FREE_BUFFER = 0x0100
+            const val USBIP_URB_DIR_IN = 0x0200
+            const val USBIP_URB_DIR_OUT = 0
+            const val USBIP_URB_DIR_MASK = USBIP_URB_DIR_IN
+
+            const val USBIP_URB_DMA_MAP_SINGLE = 0x00010000
+            const val USBIP_URB_DMA_MAP_PAGE = 0x00020000
+            const val USBIP_URB_DMA_MAP_SG = 0x00040000
+            const val USBIP_URB_MAP_LOCAL = 0x00080000
+            const val USBIP_URB_SETUP_MAP_SINGLE = 0x00100000
+            const val USBIP_URB_SETUP_MAP_LOCAL = 0x00200000
+            const val USBIP_URB_DMA_SG_COMBINED = 0x00400000
+            const val USBIP_URB_ALIGNED_TEMP_BUFFER = 0x00800000
         }
     }
 }

--- a/app/src/main/java/com/techphenom/usbipserver/server/protocol/ongoing/UsbIpSubmitUrbReply.kt
+++ b/app/src/main/java/com/techphenom/usbipserver/server/protocol/ongoing/UsbIpSubmitUrbReply.kt
@@ -51,10 +51,11 @@ class UsbIpSubmitUrbReply(seqNum: Int) :
 
     override fun toString(): String {
         val isoPacketDescriptorsString = isoPacketDescriptors.joinToString(separator = "\n", postfix = ",") { it.toString() }
+        val statusString = if (status == 0) "SUCCESS" else "NOT SUCCESSFUL"
         return """
             USBIP_RET_SUBMIT
                 ${super.toString()},
-                Status: $status (0 for successful URB transaction),
+                Status: $status (${statusString}),
                 Actual Length: $actualLength,
                 Start Frame: $startFrame,
                 Number of Packets: $numberOfPackets,

--- a/app/src/main/java/com/techphenom/usbipserver/server/protocol/usb/UsbControlHelper.kt
+++ b/app/src/main/java/com/techphenom/usbipserver/server/protocol/usb/UsbControlHelper.kt
@@ -1,5 +1,6 @@
 package com.techphenom.usbipserver.server.protocol.usb
 
+import android.hardware.usb.UsbConfiguration
 import android.hardware.usb.UsbEndpoint
 import android.hardware.usb.UsbInterface
 import android.util.SparseArray
@@ -12,6 +13,7 @@ class UsbControlHelper {
         private const val TAG = "UsbControlHelper"
         private const val GET_DESCRIPTOR_REQUEST_TYPE = 0x80
         private const val GET_DESCRIPTOR_REQUEST = 0x06
+        private const val GET_CONFIGURATION_REQUEST = 0x08
 
         private const val GET_STATUS_REQUEST_TYPE = 0x82
         private const val GET_STATUS_REQUEST = 0x00
@@ -45,38 +47,50 @@ class UsbControlHelper {
                 null
             } else UsbDeviceDescriptor(descriptorBuffer)
         }
+        fun getActiveConfigurationValue(usbLib: UsbLib, context: AttachedDeviceContext): Byte {
+            val buffer = ByteBuffer.allocateDirect(1)
+            val bytesRead = usbLib.doControlTransfer(
+                context.devConn.fileDescriptor,
+                GET_DESCRIPTOR_REQUEST_TYPE.toByte(),
+                GET_CONFIGURATION_REQUEST.toByte(),
+                0, 0,
+                buffer,
+                buffer.capacity(),
+                0
+            )
+            return if (bytesRead != 1) 0 else buffer.get()
+        }
         fun doInternalControlTransfer(
             context: AttachedDeviceContext,
             requestType: Int,
             request: Int,
             value: Int,
             index: Int
-        ): Boolean {
+        ) {
             if (requestType == SET_CONFIGURATION_REQUEST_TYPE && request == SET_CONFIGURATION_REQUEST) {
                 Logger.i(TAG, "Handling SET_CONFIGURATION via Android API")
+                val newConfig = (context.activeConfig?.id ?: -1) != value
 
                 for (i in 0..<context.device.configurationCount) {
                     val config = context.device.getConfiguration(i)
                     if (config.id == value) {
-                        // If we have a current config, we need unclaim all interfaces to allow the
-                        // configuration change to work properly.
+                        // Reset interfaces regardless if it is a new config or not
                         if (context.activeConfig != null) {
                             Logger.i(TAG,"Unclaiming all interfaces from old config: " + context.activeConfig!!.id)
                             for (j in 0..<context.activeConfig!!.interfaceCount) {
-                                val iface: UsbInterface? = context.activeConfig!!.getInterface(j)
-                                context.devConn.releaseInterface(iface)
+                                context.devConn.releaseInterface(context.activeConfig!!.getInterface(j))
                             }
                         }
 
-                        if (!context.devConn.setConfiguration(config)) {
-                            // This can happen for certain types of devices where Android itself
-                            // has set the configuration for us. Let's just hope that whatever the
-                            // client wanted is also what Android selected :/
-                            Logger.e(TAG, "Failed to set configuration! Proceeding anyway!")
+                        if (newConfig) {
+                            if (!context.devConn.setConfiguration(config)) {
+                                Logger.w(TAG, "Hardware setConfiguration($value) failed (Device might already be configured). Proceeding.")
+                            }
+                        } else {
+                            Logger.i(TAG, "Skipping hardware setConfiguration: Device already in Config $value")
                         }
 
                         context.activeConfig = config // This is now the active configuration
-                        buildEndpointCache(context)
 
                         Logger.i(TAG,"Claiming all interfaces from new configuration: " + context.activeConfig!!.id)
                         for (j in 0..<context.activeConfig!!.interfaceCount) {
@@ -86,29 +100,29 @@ class UsbControlHelper {
                             }
                         }
 
-                        return true
+                        buildEndpointCache(context)
+                        return
                     }
                 }
-
                 Logger.e(TAG, "SET_CONFIGURATION specified invalid configuration: $value")
             } else if (requestType == SET_INTERFACE_REQUEST_TYPE && request == SET_INTERFACE_REQUEST) {
                 Logger.i(TAG, "Handling SET_INTERFACE via Android API")
 
                 if (context.activeConfig == null) {
                     Logger.e(TAG, "Attempted to use SET_INTERFACE before SET_CONFIGURATION!")
-                    return false
+                    return
                 }
 
                 val currentInterface = context.activeConfig?.findInterface(index)
                 if (currentInterface == null) {
                     Logger.e(TAG, "SET_INTERFACE failed: could not find an existing interface with ID #$index")
-                    return false
+                    return
                 }
 
                 val targetInterface = context.activeConfig?.findInterface(index, value)
                 if (targetInterface == null) {
                     Logger.e(TAG, "SET_INTERFACE specified invalid interface/alternate setting: #$index/$value")
-                    return false
+                    return
                 }
 
                 Logger.i(TAG, "Releasing claim on current interface #${currentInterface.id}")
@@ -117,7 +131,7 @@ class UsbControlHelper {
                 if (!context.devConn.setInterface(targetInterface)) {
                     Logger.e(TAG, "Unable to set interface: ${targetInterface.id}. Restoring old claim.")
                     context.devConn.claimInterface(currentInterface, true)
-                    return false
+                    return
                 }
 
                 if (!context.devConn.claimInterface(targetInterface, true)) {
@@ -125,11 +139,7 @@ class UsbControlHelper {
                 }
 
                 buildEndpointCache(context)
-
-                return true
             }
-
-            return false
         }
 
         fun buildEndpointCache(context: AttachedDeviceContext) {
@@ -146,7 +156,7 @@ class UsbControlHelper {
             }
         }
 
-        private fun android.hardware.usb.UsbConfiguration.findInterface(id: Int, alternateSetting: Int? = null): UsbInterface? {
+        private fun UsbConfiguration.findInterface(id: Int, alternateSetting: Int? = null): UsbInterface? {
             for (i in 0..<this.interfaceCount) {
                 val iface = this.getInterface(i)
                 if (iface.id == id && (alternateSetting == null || iface.alternateSetting == alternateSetting)) {

--- a/app/src/main/java/com/techphenom/usbipserver/server/protocol/usb/UsbControlHelper.kt
+++ b/app/src/main/java/com/techphenom/usbipserver/server/protocol/usb/UsbControlHelper.kt
@@ -14,23 +14,10 @@ class UsbControlHelper {
         private const val GET_DESCRIPTOR_REQUEST_TYPE = 0x80
         private const val GET_DESCRIPTOR_REQUEST = 0x06
         private const val GET_CONFIGURATION_REQUEST = 0x08
-
-        private const val GET_STATUS_REQUEST_TYPE = 0x82
-        private const val GET_STATUS_REQUEST = 0x00
-
-        private const val CLEAR_FEATURE_REQUEST_TYPE = 0x02
-        private const val CLEAR_FEATURE_REQUEST = 0x01
-
         private const val SET_CONFIGURATION_REQUEST_TYPE: Int = 0x00
         private const val SET_CONFIGURATION_REQUEST: Int = 0x9
-
         private const val SET_INTERFACE_REQUEST_TYPE: Int = 0x01
         private const val SET_INTERFACE_REQUEST: Int = 0xB
-
-        private const val SET_ADDRESS_REQUEST_TYPE: Int = 0x00
-        private const val SET_ADDRESS_REQUEST: Int = 0x05
-
-        private const val FEATURE_VALUE_HALT = 0x00
 
         private const val DEVICE_DESCRIPTOR_TYPE = 1
 

--- a/app/src/main/java/com/techphenom/usbipserver/server/protocol/usb/UsbLib.kt
+++ b/app/src/main/java/com/techphenom/usbipserver/server/protocol/usb/UsbLib.kt
@@ -40,7 +40,8 @@ class UsbLib {
         fd: Int,
         data: ByteBuffer,
         timeout: Int,
-        seqNum: Int
+        seqNum: Int,
+        flags: Int
     ): Int
 
     external fun doBulkTransferAsync(
@@ -48,7 +49,8 @@ class UsbLib {
         endpoint: Int,
         data: ByteBuffer,
         timeout: Int,
-        seqNum: Int
+        seqNum: Int,
+        flags: Int
     ): Int
 
     external fun doInterruptTransferAsync(
@@ -56,7 +58,8 @@ class UsbLib {
         endpoint: Int,
         data: ByteBuffer,
         timeout: Int,
-        seqNum: Int
+        seqNum: Int,
+        flags: Int
     ): Int
 
     external fun doIsochronousTransferAsync(
@@ -64,7 +67,8 @@ class UsbLib {
         endpoint: Int,
         data: ByteBuffer,
         isoPacketLengths: IntArray,
-        seqNum: Int
+        seqNum: Int,
+        flags: Int
     ): Int
 
 }

--- a/app/src/main/java/com/techphenom/usbipserver/server/protocol/utils/StringFormattingUtil.kt
+++ b/app/src/main/java/com/techphenom/usbipserver/server/protocol/utils/StringFormattingUtil.kt
@@ -21,3 +21,7 @@ fun intToHex(value: Int): String {
     }
     return value.toHexString(format)
 }
+
+fun intToBinary(value: Int): String {
+    return value.toString(2).padStart(8, '0')
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,4 +25,4 @@ android.nonTransitiveRClass=true
 # Application Versioning
 APP_VERSION_MAJOR=0
 APP_VERSION_MINOR=5
-APP_VERSION_PATCH=0
+APP_VERSION_PATCH=1


### PR DESCRIPTION
## Changes :gear: 
  - Fixed major semaphore bug.
    - I was running all control transfer exclusively when only SET_CONFIG and SET_INTERFACE should be. This was causing disconnects because a bunch of control transfers in a row would clog up the traffic.
  - Passing down the transfer_flags now.
    - The only two that are being used by libusb are Short Not OK (0x0001) and Zero Packet (ZLP) (0x0040)
  - Changed detectSpeed
  - More detailed logs